### PR TITLE
(WiiU) Get rid of heap and fix memory size

### DIFF
--- a/libpcsxcore/ppc_dynarec/pR3000A.h
+++ b/libpcsxcore/ppc_dynarec/pR3000A.h
@@ -36,7 +36,7 @@
 /* defines */
 #if defined(HW_WUP)
 // For now this is in MEM0, so it needs to be conservative
-#define RECMEM_SIZE     (0x00F00000)
+#define RECMEM_SIZE     (0x01000000 - 0x00802000)
 #elif defined(HW_RVL)
 #define RECMEM_SIZE		(7*1024*1024)
 #else


### PR DESCRIPTION
A heap is kinda pointless if we're only making one allocation. Emulator wasn't initialising since the memory area is only 0x7fe000 instead of 0xf00000, fix it to do readable maths.